### PR TITLE
Bumping utf8-string (1), filepath (1.4) and LibZip (1.0).

### DIFF
--- a/zip-conduit.cabal
+++ b/zip-conduit.cabal
@@ -23,12 +23,12 @@ Library
     , conduit        >= 1.1 && < 1.3
     , digest         == 0.0.*
     , directory      >= 1.1 && < 1.3
-    , filepath       == 1.3.*
+    , filepath       >= 1.3 && < 1.5
     , mtl            >= 2.0 && < 2.3
     , old-time       >= 1.0 && < 1.2
     , time           >= 1.4 && < 1.6
     , transformers   >= 0.3 && < 0.5
-    , utf8-string    == 0.3.*
+    , utf8-string    >= 0.3 && <= 1
     , conduit-extra  == 1.1.*
     , resourcet      == 1.1.*
 
@@ -54,7 +54,7 @@ Test-suite tests
     , conduit        >= 1.1 && < 1.3
     , resourcet      == 1.1.*
     , directory      >= 1.1 && < 1.3
-    , filepath       == 1.3.*
+    , filepath       >= 1.3 && < 1.5
     , HUnit          == 1.2.*
     , hpc            >= 0.5 && < 0.7
     , mtl            >= 2.0 && < 2.3
@@ -78,8 +78,8 @@ Benchmark bench
     , bytestring     >= 0.9 && < 0.11
     , directory      >= 1.1 && < 1.3
     , criterion      == 1.0.*
-    , filepath       == 1.3.*
-    , LibZip         >= 0.10 && < 0.12
+    , filepath       >= 1.3 && < 1.5
+    , LibZip         >= 0.10 && < 1.1
     , random         >= 1.0 && < 1.2
     , temporary      >= 1.1 && < 1.3
     , zip-archive    >= 0.1 && < 0.3


### PR DESCRIPTION
Version bumps so that zip-archive builds with the current Hackage. Note that LibZip 1.0 (to match the 1.0 version of the library) has not been released yet, but [it is in the works](https://bitbucket.org/astanin/hs-libzip/commits/492b24077b59ebcc885c4a80bdc03dc34f04a41e) (I didn't run the benchmark against it, though).